### PR TITLE
fix mirtop version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * conda-forge::r-statmod=1.4.30 -> 1.4.32
 * conda-forge::r-markdown=0.9 -> 1.0
 * trim-galore=0.6.2 -> 0.6.3
-* mirtop=0.4.18a -> 0.4.20
+* mirtop=0.4.18a -> 0.4.21
 * bioconductor-edger=3.26.0 -> 3.26.5
 * bioconductor-limma=3.40.0 -> 3.40.2
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - samtools=1.9
   - bowtie=1.2.2
   - multiqc=1.7
-  - mirtop=0.4.20
+  - mirtop=0.4.21
   - seqcluster=1.2.5
   - htseq=0.11.2
   - fastx_toolkit=0.0.14


### PR DESCRIPTION
Update to last `mirtop` version to fix an important bug.
The docker builds correctly locally and it works with the open PR code I have.
Hopefully, after this, I can finish the PR and if we get test passes, we'll get a release soon!