### PR TITLE
make sure one file is used in collapse step

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -396,13 +396,14 @@ process collapse {
     file reads from trimmed_reads_collapse
 
     output:
-    file 'collapsed/*.fastq' into collapsed_fasta
+    file 'final/*.fastq' into collapsed_fasta
 
     script:
     prefix = reads.toString() - '_trimmed.fq.gz'
     """
     seqcluster collapse -f $reads -m 1 --min_size 15 -o collapsed
-    mv collapsed/${prefix}_trimmed_trimmed.fastq collapsed/${prefix}.fastq
+    mkdir final
+    mv collapsed/${prefix}_trimmed_trimmed.fastq final/${prefix}.fastq
     """
 }
 


### PR DESCRIPTION
this is related to UMI in the fastq files. Address: 
https://github.com/nf-core/smrnaseq/issues/35

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/smrnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/smrnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md
