### PR TITLE
Speed up bowtie-build using multithreading

### DIFF
--- a/bin/edgeR_miRBase.r
+++ b/bin/edgeR_miRBase.r
@@ -68,12 +68,24 @@ for (i in 1:2) {
 
     # Remove genes with 0 reads in all samples
     row_sub = apply(data, 1, function(row) all(row ==0 ))
-    data<-data[!row_sub,,drop=FALSE]
+
+    data<-data[!row_sub,]
+    write.csv(t(data),file=paste(header,"_counts.csv",sep=""))
 
     # Normalization
     dataDGE<-DGEList(counts=data,genes=rownames(data))
     o <- order(rowSums(dataDGE$counts), decreasing=TRUE)
     dataDGE <- dataDGE[o,]
+                    
+    # Save log10(TPM)
+    tpm = cpm(dataDGE, normalized.lib.sizes=F, log = F, prior.count = 0.001)
+    tpm = tpm + 0.001
+    tpm = log10(tpm)
+    ttpm = t(tpm)
+    write.table(ttpm,file=paste(header,"_logtpm.txt",sep=""),sep='\t',quote=FALSE)
+    write.csv(ttpm,file=paste(header,"_logtpm.csv",sep=""))
+                    
+    # TMM
     dataNorm <- calcNormFactors(dataDGE)
 
     # Print normalized read counts to file

--- a/main.nf
+++ b/main.nf
@@ -333,7 +333,7 @@ if (!params.references_parsed && !params.skip_mirdeep){
     sed -i 's, ,_,g' \$MATURE
 
     # Build bowtie index
-    bowtie-build genome.fa genome --threads $(nproc) 
+    bowtie-build genome.fa genome --threads \$(nproc) 
     """
   }
 }
@@ -360,13 +360,13 @@ process make_bowtie_index {
     seqkit seq --rna2dna mature_sps.fa > mature_igenome.fa
     fasta_formatter -w 0 -i mature_igenome.fa -o mature_idx.fa
     # fasta_nucleotide_changer -d -i mature_igenome.fa -o mature_idx.fa
-    bowtie-build mature_idx.fa mature_idx --threads $(nproc) 
+    bowtie-build mature_idx.fa mature_idx --threads \$(nproc) 
 
     seqkit grep -r --pattern \".*${params.mirtrace_species}-.*\" $hairpin > hairpin_sps.fa
     seqkit seq --rna2dna hairpin_sps.fa > hairpin_igenome.fa
     # fasta_nucleotide_changer -d -i hairpin_igenome.fa -o hairpin_idx.fa
     fasta_formatter -w 0 -i hairpin_igenome.fa -o hairpin_idx.fa
-    bowtie-build hairpin_idx.fa hairpin_idx --threads $(nproc) 
+    bowtie-build hairpin_idx.fa hairpin_idx --threads \$(nproc) 
     """
 }
 
@@ -638,7 +638,7 @@ process edgeR_mirna {
 process mirtop_bam_hairpin {
     label 'process_medium'
     tag "$input"
-    publishDir "${params.outdir}", mode: 'copy'
+    publishDir "${params.outdir}", mode: 'cbopy'
 
     when:
     mirna_gtf

--- a/main.nf
+++ b/main.nf
@@ -333,7 +333,7 @@ if (!params.references_parsed && !params.skip_mirdeep){
     sed -i 's, ,_,g' \$MATURE
 
     # Build bowtie index
-    bowtie-build genome.fa genome
+    bowtie-build genome.fa genome --threads $(nproc) 
     """
   }
 }
@@ -360,13 +360,13 @@ process make_bowtie_index {
     seqkit seq --rna2dna mature_sps.fa > mature_igenome.fa
     fasta_formatter -w 0 -i mature_igenome.fa -o mature_idx.fa
     # fasta_nucleotide_changer -d -i mature_igenome.fa -o mature_idx.fa
-    bowtie-build mature_idx.fa mature_idx
+    bowtie-build mature_idx.fa mature_idx --threads $(nproc) 
 
     seqkit grep -r --pattern \".*${params.mirtrace_species}-.*\" $hairpin > hairpin_sps.fa
     seqkit seq --rna2dna hairpin_sps.fa > hairpin_igenome.fa
     # fasta_nucleotide_changer -d -i hairpin_igenome.fa -o hairpin_idx.fa
     fasta_formatter -w 0 -i hairpin_igenome.fa -o hairpin_idx.fa
-    bowtie-build hairpin_idx.fa hairpin_idx
+    bowtie-build hairpin_idx.fa hairpin_idx --threads $(nproc) 
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -624,7 +624,7 @@ process edgeR_mirna {
     file input_files from miRBase_counts.toSortedList()
 
     output:
-    file '*.{txt,pdf}' into edgeR_miRBase_results
+    file '*.{txt,pdf,csv}' into edgeR_miRBase_results
 
     script:
     """


### PR DESCRIPTION
This simple change speeds up the bowtie-build process.
I have added `--threads $(nproc)` to all `bowtie-build` commands.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/smrnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/smrnaseq)
 - [x ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md
