### PR TITLE
Use HTTPS instead of FTP for downloading miRBase files

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -20,8 +20,8 @@ params {
   bt_indices = null
   mirtrace_protocol = false
   references_parsed = false
-  mature = "ftp://mirbase.org/pub/mirbase/CURRENT/mature.fa.gz"
-  hairpin = "ftp://mirbase.org/pub/mirbase/CURRENT/hairpin.fa.gz"
+  mature = "https://mirbase.org/ftp/CURRENT/mature.fa.gz"
+  hairpin = "https://mirbase.org/ftp/CURRENT/hairpin.fa.gz"
 
   // Trimming options
   clip_r1 = 0


### PR DESCRIPTION
On our HPC cluster, the FTP URLs of miRBase were not reachable, but their HTTPS counterparts worked well.  As FTP does not present advantages over HTTPS for downloading single files and tends to be phased out anyway, I suggest to use HTTPS for robustness.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](<https://github.com/>nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
