### PR TITLE
Fix seqcluster umi bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other enhancements & fixes
 
 - [#134](https://github.com/nf-core/smrnaseq/issues/134) - Fixed colSum of zero issues for edgeR_miRBase.R script
+- [#55](https://github.com/lpantano/seqcluster/pull/55) - update seqcluster to fix UMI-detecting bug
 
 ### Parameters
 
@@ -51,7 +52,7 @@ Note, since the pipeline is now using Nextflow DSL2, each process will be run wi
 | `r-gplots`           | 3.0.1.1     | 3.1.1       |
 | `r-statmod`          | 1.4.32      | 1.4.36      |
 | `samtools`           | 1.12        | 1.13        |
-| `seqcluster`         | 1.2.7       | 1.2.8       |
+| `seqcluster`         | 1.2.7       | 1.2.9       |
 | `seqkit`             | 0.16.0      | 2.0.0       |
 | `trim-galore`        | 0.6.6       | 0.6.7       |
 | `bioconvert`         | -           | 0.4.3       |

--- a/modules/local/seqcluster_collapse.nf
+++ b/modules/local/seqcluster_collapse.nf
@@ -2,9 +2,9 @@ process SEQCLUSTER_SEQUENCES {
     label 'process_medium'
     tag "$meta.id"
 
-    conda (params.enable_conda ? 'bioconda::seqcluster=1.2.8-0' : null)
+    conda (params.enable_conda ? 'bioconda::seqcluster=1.2.9-0' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/seqcluster:1.2.8--pyh5e36f6f_0' :
+        'https://depot.galaxyproject.org/singularity/seqcluster:1.2.9--pyh5e36f6f_0' :
         'quay.io/biocontainers/seqcluster:1.2.8--pyh5e36f6f_0' }"
 
     input:


### PR DESCRIPTION
update seqcluster version from 1.2.8 to 1.2.9. New version of seqcluster fixes bug where UMI detection is mistakenly attempted

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.

