### PR TITLE
Fix bug when --bowtie_indices is provided via the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 - Trimmed output was not as documented and not correctly published [#161](https://github.com/nf-core/smrnaseq/issues/161)
+- Index files were not collected when `bowtie_indices` was used and thus mapping was failing [#159](https://github.com/nf-core/smrnaseq/issues/159)
 
 ### Other enhancements
 

--- a/subworkflows/local/genome_quant.nf
+++ b/subworkflows/local/genome_quant.nf
@@ -17,7 +17,7 @@ workflow GENOME_QUANT {
 
     if (!bt_index){
         INDEX_GENOME ( fasta )
-        bowtie_indices      = INDEX_GENOME.out.bowtie_indices
+        bowtie_indices  = INDEX_GENOME.out.bowtie_indices
         fasta_formatted = INDEX_GENOME.out.fasta
         ch_versions     = ch_versions.mix(INDEX_GENOME.out.versions)
     } else {

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -59,7 +59,7 @@ if (!params.mirGeneDB) {
 } else {
     if (params.mirGeneDB_mature) { reference_mature = file(params.mirGeneDB_mature, checkIfExists: true) } else { exit 1, "Mature miRNA fasta file not found: ${params.mirGeneDB_mature}" }
     if (params.mirGeneDB_hairpin) { reference_hairpin = file(params.mirGeneDB_hairpin, checkIfExists: true) } else { exit 1, "Hairpin miRNA fasta file not found: ${params.mirGeneDB_hairpin}" }
-    if (params.mirGeneDB_gff) { mirna_gtf = file(params.mirGeneDB_gff, checkIfExists: true) } else { exit 1, "MirGeneDB gff file not found: ${params.mirGeneDB_gff}"}  
+    if (params.mirGeneDB_gff) { mirna_gtf = file(params.mirGeneDB_gff, checkIfExists: true) } else { exit 1, "MirGeneDB gff file not found: ${params.mirGeneDB_gff}"}
     params.filterSpecies = params.mirGeneDB_species
 }
 
@@ -169,7 +169,13 @@ workflow SMRNASEQ {
         ch_versions = ch_versions.mix(GENOME_QUANT.out.versions)
 
         if (!params.skip_mirdeep) {
-            MIRDEEP2 (FASTQC_TRIMGALORE.out.reads, GENOME_QUANT.out.fasta, GENOME_QUANT.out.indices, MIRNA_QUANT.out.fasta_hairpin, MIRNA_QUANT.out.fasta_mature)
+            MIRDEEP2 (
+                FASTQC_TRIMGALORE.out.reads,
+                GENOME_QUANT.out.fasta,
+                GENOME_QUANT.out.indices.collect(),
+                MIRNA_QUANT.out.fasta_hairpin,
+                MIRNA_QUANT.out.fasta_mature
+            )
             ch_versions = ch_versions.mix(MIRDEEP2.out.versions)
         }
     }


### PR DESCRIPTION
Fixes #159 
The problem was that not all the index files were staged in the work dir, see #159 for more background.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
