### PR TITLE
Fix for #168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Index files were not collected when `bowtie_indices` was used and thus mapping was failing [#159](https://github.com/nf-core/smrnaseq/issues/159)
 - Fixed issue with mirTop and MultiQC by upgrading to MultiQC V1.13dev [#137](https://github.com/nf-core/smrnaseq/issues/137)
 - Improved Bowtie index handling which should be more stable now and follow nf-core/modules approach
+- Removed `mirtrace_protocol` as the parameter was redundant and `params.protocol` is entirely sufficient [#168](https://github.com/nf-core/smrnaseq/issues/168)
 
 ### Other enhancements
 

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -30,11 +30,8 @@ process MIRTRACE_RUN {
         three_prime_adapter = params.three_prime_adapter
     }
     // mirtrace protocol defaults to 'params.protocol' if not set
-    def mirtrace_protocol = params.mirtrace_protocol
-    if (!params.mirtrace_protocol){
-        mirtrace_protocol = params.protocol
-    }
-    def primer = (mirtrace_protocol=="cats") ? " " : " --adapter $three_prime_adapter "
+    def protocol = params.protocol
+    def primer = (protocol=="cats") ? " " : " --adapter $three_prime_adapter "
     def java_mem = ''
     if(task.memory){
         tmem = task.memory.toBytes()
@@ -52,7 +49,7 @@ process MIRTRACE_RUN {
     java $java_mem -jar \$mirtracejar/mirtrace.jar --mirtrace-wrapper-name mirtrace qc  \\
         --species $params.mirtrace_species \\
         $primer \\
-        --protocol $mirtrace_protocol \\
+        --protocol $protocol \\
         --config mirtrace_config \\
         --write-fasta \\
         --output-dir mirtrace \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,6 @@ params {
     mirna_gtf                  = null
     bowtie_indices             = null
     mirtrace_species           = null
-    mirtrace_protocol          = 'illumina'
     mature                     = "https://mirbase.org/ftp/CURRENT/mature.fa.gz"
     hairpin                    = "https://mirbase.org/ftp/CURRENT/hairpin.fa.gz"
     mirGeneDB                  = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -178,14 +178,6 @@
                     "fa_icon": "fas fa-text-width",
                     "description": "Sequencing adapter sequence to use for trimming."
                 },
-                "mirtrace_protocol": {
-                    "type": "string",
-                    "default": "illumina",
-                    "fa_icon": "fas fa-vial",
-                    "description": "The miRTrace protocol for QC reporting.",
-                    "help_text": "miRTrace can handle four protocols, each with their own primer-read structure. See the protocol descriptions [here](https://github.com/friedlanderlab/mirtrace/blob/master/release-bundle-includes/doc/manual/mirtrace_manual.pdf).",
-                    "enum": ["illumina", "cats", "qiaseq", "nextflex"]
-                },
                 "trim_galore_max_length": {
                     "type": "integer",
                     "default": 40,


### PR DESCRIPTION
This removes the `mirtrace_protocol` as it was redundant and apparently always set to `params.protocol` - issue  reported by @gpalidwor and fixed in this PR - see details in #168 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
