### PR TITLE
Fix protocol consistency

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,9 @@ This option indicates the experimental protocol used for the sample preparation.
 - 'nextflex': adapter (`TGGAATTCTCGGGTGCCAAGG), clip_r1 (`4`), three_prime_clip_r1 (`4`)
 - 'qiaseq': adapter (`AACTGTAGGCACCATCAAT`)
 - 'cats': adapter (`GATCGGAAGAGCACACGTCTG), clip_r1(`3)
-- 'custom' (where the ser can indicate the `three_prime_adapter`, `clip_r1` and three_prime_clip_r1`)
+- 'custom' (where the user can indicate the `three_prime_adapter`, `clip_r1` and `three_prime_clip_r1` manually)
+
+:warning: At least the `custom` protocol has to be specified, otherwise the pipeline won't run.
 
 ### `mirtrace_species or mirGeneDB_species`
 

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -29,8 +29,8 @@ process MIRTRACE_RUN {
     }
 
     // mirtrace protocol defaults to 'params.protocol' if not set
-    def protocol = params.protocol
     def primer = (protocol=="cats") ? " " : " --adapter $three_prime_adapter "
+    def protocol = (protocol=="custom") ? "" : "--protocol $params.protocol"
     def java_mem = ''
     if(task.memory){
         tmem = task.memory.toBytes()
@@ -48,7 +48,7 @@ process MIRTRACE_RUN {
     java $java_mem -jar \$mirtracejar/mirtrace.jar --mirtrace-wrapper-name mirtrace qc  \\
         --species $params.mirtrace_species \\
         $primer \\
-        --protocol $protocol \\
+        $protocol \\
         --config mirtrace_config \\
         --write-fasta \\
         --output-dir mirtrace \\

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -29,8 +29,8 @@ process MIRTRACE_RUN {
     }
 
     // mirtrace protocol defaults to 'params.protocol' if not set
-    def primer = (protocol=="cats") ? " " : " --adapter $three_prime_adapter "
-    def protocol = (protocol=="custom") ? "" : "--protocol $params.protocol"
+    def primer = (params.protocol=="cats") ? " " : " --adapter $three_prime_adapter "
+    def protocol = (params.protocol=="custom") ? " " : "--protocol $params.protocol"
     def java_mem = ''
     if(task.memory){
         tmem = task.memory.toBytes()

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -24,11 +24,10 @@ process MIRTRACE_RUN {
         three_prime_adapter = "AACTGTAGGCACCATCAAT"
     } else if (params.protocol == "cats"){
         three_prime_adapter = "AAAAAAAA"
-    }
-    if (params.three_prime_adapter){
-        // to allow replace of 3' primer using one of the previous protocols
+    } else if (params.protocol == "custom"){
         three_prime_adapter = params.three_prime_adapter
     }
+
     // mirtrace protocol defaults to 'params.protocol' if not set
     def protocol = params.protocol
     def primer = (protocol=="cats") ? " " : " --adapter $three_prime_adapter "

--- a/modules/local/trimgalore.nf
+++ b/modules/local/trimgalore.nf
@@ -51,12 +51,11 @@ process TRIMGALORE {
         three_prime_clip_r1 = 0
         // three_prime_adapter = "GATCGGAAGAGCACACGTCTG"
         three_prime_adapter = "AAAAAAAA"
-    } else {
+    } else if (params.protocol == "custom"){
         //custom protocol
         clip_r1 = params.clip_r1
         three_prime_clip_r1 = params.three_prime_clip_r1
         three_prime_adapter = params.three_prime_adapter
-        protocol = params.protocol
     }
     def tg_length = "--length ${params.min_length}"
     def c_r1 = clip_r1 > 0 ? "--clip_r1 ${clip_r1}" : ''


### PR DESCRIPTION
This should fix the inconsistencies between what is used in trimgalore and in mirtrace. Now keeps things the same.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
