### PR TITLE
Standardise genome parameters and fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#12](https://github.com/nf-core/smrnaseq/issues/12)] - Enabled the use of `MirGeneDB` as an alternative database insted of `miRBase`
 - [[#113](https://github.com/nf-core/smrnaseq/issues/113)] - Added a optional contamination filtering step, including MultiQC plot
 - [[#137](https://github.com/nf-core/smrnaseq/issues/137)] - Fixed issue with mirTop and MultiQC by upgrading to MultiQC V1.13dev
-- [[#159](https://github.com/nf-core/smrnaseq/issues/159)] - Index files were not collected when `bowtie_indices` was used and thus mapping was failing
+- [[#159](https://github.com/nf-core/smrnaseq/issues/159)] - Index files were not collected when `bowtie_index` was used and thus mapping was failing
 - [[#161](https://github.com/nf-core/smrnaseq/issues/161)] - Trimmed output was not as documented and not correctly published
 - [[#168](https://github.com/nf-core/smrnaseq/issues/168)] - Removed `mirtrace_protocol` as the parameter was redundant and `params.protocol` is entirely sufficient
 - Updated pipeline template to [nf-core/tools 2.5.1](https://github.com/nf-core/tools/releases/tag/2.5.1)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -179,46 +179,40 @@ process {
     }
 }
 
-def fasta_from_species = false
-def fasta = false
-fasta_from_species = params.genome ? params.genomes[ params.genome ].fasta ?: false : false
-fasta = params.fasta ?: fasta_from_species
-if (fasta) {
+process {
+    withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:SAMTOOLS_.*' {
+        ext.prefix = { "${meta.id}.sorted" }
+        publishDir = [
+            path: { "${params.outdir}/samtools" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:BAM_STATS_SAMTOOLS:.*' {
+        ext.prefix = { "${meta.id}.sorted" }
+        publishDir = [
+            path: { "${params.outdir}/samtools/samtools_stats" },
+            mode: params.publish_dir_mode,
+            pattern: "*.{stats,flagstat,idxstats}"
+        ]
+    }
+    withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BOWTIE_MAP_.*' {
+        publishDir = [
+            path: { "${params.outdir}/unmapped/fastq" },
+            mode: params.publish_dir_mode,
+            pattern: "unmapped/*.gz"
+        ]
+    }
+}
+
+if (!params.skip_mirdeep) {
     process {
-        withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:SAMTOOLS_.*' {
-            ext.prefix = { "${meta.id}.sorted" }
+        withName: 'MIRDEEP2_MAPPER' {
             publishDir = [
-                path: { "${params.outdir}/samtools" },
+                path: { "${params.outdir}/mirdeep" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
-        }
-        withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:BAM_STATS_SAMTOOLS:.*' {
-            ext.prefix = { "${meta.id}.sorted" }
-            publishDir = [
-                path: { "${params.outdir}/samtools/samtools_stats" },
-                mode: params.publish_dir_mode,
-                pattern: "*.{stats,flagstat,idxstats}"
-            ]
-        }
-        withName: 'NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BOWTIE_MAP_.*' {
-            publishDir = [
-                path: { "${params.outdir}/unmapped/fastq" },
-                mode: params.publish_dir_mode,
-                pattern: "unmapped/*.gz"
-            ]
-        }
-    }
-
-    if (!params.skip_mirdeep) {
-        process {
-            withName: 'MIRDEEP2_MAPPER' {
-                publishDir = [
-                    path: { "${params.outdir}/mirdeep" },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
         }
     }
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -11,8 +11,6 @@
 */
 
 params {
-    max_memory = '12.GB'
-    max_cpus = 8
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'
 

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@
     nf-core/smrnaseq
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Github : https://github.com/nf-core/smrnaseq
-Website: https://nf-co.re/smrnaseq
+    Website: https://nf-co.re/smrnaseq
     Slack  : https://nfcore.slack.com/channels/smrnaseq
 ----------------------------------------------------------------------------------------
 */
@@ -16,6 +16,10 @@ nextflow.enable.dsl = 2
     GENOME PARAMETER VALUES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
+
+params.fasta            = WorkflowMain.getGenomeAttribute(params, 'fasta')
+params.mirtrace_species = WorkflowMain.getGenomeAttribute(params, 'mirtrace_species')
+params.bowtie_index     = WorkflowMain.getGenomeAttribute(params, 'bowtie')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules/local/bowtie_contaminants.nf
+++ b/modules/local/bowtie_contaminants.nf
@@ -10,7 +10,7 @@ process INDEX_CONTAMINANTS {
     path fasta
 
     output:
-    path 'fasta_bidx*'  , emit: bt_indices
+    path 'fasta_bidx*'  , emit: index
     path "versions.yml" , emit: versions
 
     script:

--- a/modules/local/bowtie_genome.nf
+++ b/modules/local/bowtie_genome.nf
@@ -11,7 +11,7 @@ process INDEX_GENOME {
     path fasta
 
     output:
-    path 'genome*ebwt'     , emit: bowtie_indices
+    path 'genome*ebwt'     , emit: index
     path 'genome.edited.fa', emit: fasta
     path "versions.yml"    , emit: versions
 

--- a/modules/local/bowtie_mirna.nf
+++ b/modules/local/bowtie_mirna.nf
@@ -10,7 +10,7 @@ process INDEX_MIRNA {
     path fasta
 
     output:
-    path 'fasta_bidx*' , emit: bowtie_indices
+    path 'fasta_bidx*' , emit: index
     path "versions.yml", emit: versions
 
     script:

--- a/modules/local/mirtop_quant.nf
+++ b/modules/local/mirtop_quant.nf
@@ -11,8 +11,6 @@ process MIRTOP_QUANT {
     path hairpin
     path gtf
 
-    //if (!params.mirgenedb) {params.filter_species = params.mirtrace_species} else {params.filter_species = params.mirgenedb_species}
-
     output:
     path "mirtop/mirtop.gff"
     path "mirtop/mirtop.tsv"        , emit: mirtop_table
@@ -21,10 +19,11 @@ process MIRTOP_QUANT {
     path "versions.yml"             , emit: versions
 
     script:
+    def filter_species = params.mirgenedb ? params.mirgenedb_species : params.mirtrace_species
     """
-    mirtop gff --hairpin $hairpin --gtf $gtf -o mirtop --sps $params.filter_species ./bams/*
-    mirtop counts --hairpin $hairpin --gtf $gtf -o mirtop --sps $params.filter_species --add-extra --gff mirtop/mirtop.gff
-    mirtop export --format isomir --hairpin $hairpin --gtf $gtf --sps $params.filter_species -o mirtop mirtop/mirtop.gff
+    mirtop gff --hairpin $hairpin --gtf $gtf -o mirtop --sps $filter_species ./bams/*
+    mirtop counts --hairpin $hairpin --gtf $gtf -o mirtop --sps $filter_species --add-extra --gff mirtop/mirtop.gff
+    mirtop export --format isomir --hairpin $hairpin --gtf $gtf --sps $filter_species -o mirtop mirtop/mirtop.gff
     mirtop stats mirtop/mirtop.gff --out mirtop/stats
     mv mirtop/stats/mirtop_stats.log mirtop/stats/full_mirtop_stats.log
 

--- a/modules/local/parse_fasta_mirna.nf
+++ b/modules/local/parse_fasta_mirna.nf
@@ -9,13 +9,12 @@ process PARSE_FASTA_MIRNA {
     input:
     path fasta
 
-    //if (!params.mirgenedb) {params.filter_species = params.mirtrace_species} else {params.filter_species = params.mirgenedb_species}
-
     output:
     path '*_igenome.fa', emit: parsed_fasta
     path "versions.yml", emit: versions
 
     script:
+    def filter_species = params.mirgenedb ? params.mirgenedb_species : params.mirtrace_species
     """
     # Uncompress FASTA reference files if necessary
     FASTA="$fasta"
@@ -29,7 +28,7 @@ process PARSE_FASTA_MIRNA {
     # TODO perl -ane 's/[ybkmrsw]/N/ig;print;' \${FASTA}_parsed_tmp.fa > \${FASTA}_parsed.fa
 
     sed -i 's/\s.*//' \${FASTA}_parsed.fa
-    seqkit grep -r --pattern \".*${params.filter_species}-.*\" \${FASTA}_parsed.fa > \${FASTA}_sps.fa
+    seqkit grep -r --pattern \".*${filter_species}-.*\" \${FASTA}_parsed.fa > \${FASTA}_sps.fa
     seqkit seq --rna2dna \${FASTA}_sps.fa > \${FASTA}_igenome.fa
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,21 +19,18 @@ params {
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes'
     igenomes_ignore            = false
-    fasta                      = null
     mirna_gtf                  = null
-    bowtie_indices             = null
-    mirtrace_species           = null
     mature                     = "https://mirbase.org/ftp/CURRENT/mature.fa.gz"
     hairpin                    = "https://mirbase.org/ftp/CURRENT/hairpin.fa.gz"
     mirgenedb                  = false
-    mirgenedb_mature           = "/Users/chriskub/Downloads/ALL-mat.fas"
-    mirgenedb_hairpin          = "/Users/chriskub/Downloads/ALL-pre.fas"
-    mirgenedb_gff              = "/Users/chriskub/Downloads/ALL.gff"
+    mirgenedb_mature           = null
+    mirgenedb_hairpin          = null
+    mirgenedb_gff              = null
     mirgenedb_species          = null
 
     // Trimming options
-    clip_r1                    = 0
-    three_prime_clip_r1        = 0
+    clip_r1                    = null
+    three_prime_clip_r1        = null
     three_prime_adapter        = "TGGAATTCTCGGGTGCCAAGG"
     min_length                 = 17
     skip_qc                    = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -65,8 +65,7 @@
                 "mirgenedb": {
                     "type": "boolean",
                     "description": "Boolean whether MirGeneDB should be used instead of miRBase",
-                    "help_text": "This allows you to use MirGeneDB instead of miRBase as the database. \n Note that you will need to set the additional flags `--mirgenedb_species`, `--mirgenedb_gff`, `--mirgenedb_mature` and `--mirgenedb_hairpin`",
-                    "default": "false"
+                    "help_text": "This allows you to use MirGeneDB instead of miRBase as the database. \n Note that you will need to set the additional flags `--mirgenedb_species`, `--mirgenedb_gff`, `--mirgenedb_mature` and `--mirgenedb_hairpin`"
                 },
                 "mirtrace_species": {
                     "type": "string",
@@ -120,7 +119,7 @@
                     "description": "Path to FASTA file with miRNAs precursors.",
                     "help_text": "This file needs to be downloaded from [`https://mirgenedb.org/download`]. Can be given either as a plain text `.fa` file or a compressed `.gz` file.\nNote that MirGeneDB does not have a dedicated hairpin file. The equivalent is the `Precursor sequences`."
                 },
-                "bowtie_indices": {
+                "bowtie_index": {
                     "type": "string",
                     "description": "Path to a Bowtie 1 index directory",
                     "fa_icon": "fas fa-book",

--- a/subworkflows/local/contaminant_filter.nf
+++ b/subworkflows/local/contaminant_filter.nf
@@ -49,7 +49,7 @@ workflow CONTAMINANT_FILTER {
         // Index DB and filter $reads emit: $rrna_reads
         INDEX_RRNA ( rrna )
         ch_versions = ch_versions.mix(INDEX_RRNA.out.versions)
-        MAP_RRNA ( reads, INDEX_RRNA.out.bt_indices, 'rRNA' )
+        MAP_RRNA ( reads, INDEX_RRNA.out.index, 'rRNA' )
         ch_versions = ch_versions.mix(MAP_RRNA.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_RRNA.out.stats.ifEmpty(null))
         MAP_RRNA.out.unmapped.set { rrna_reads }
@@ -61,7 +61,7 @@ workflow CONTAMINANT_FILTER {
         // Index DB and filter $rrna_reads emit: $trna_reads
         INDEX_TRNA ( trna )
         ch_versions = ch_versions.mix(INDEX_TRNA.out.versions)
-        MAP_TRNA ( rrna_reads, INDEX_TRNA.out.bt_indices, 'tRNA')
+        MAP_TRNA ( rrna_reads, INDEX_TRNA.out.index, 'tRNA')
         ch_versions = ch_versions.mix(MAP_TRNA.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_TRNA.out.stats.ifEmpty(null))
         MAP_TRNA.out.unmapped.set { trna_reads }
@@ -75,7 +75,7 @@ workflow CONTAMINANT_FILTER {
         ch_versions = ch_versions.mix(BLAT_CDNA.out.versions)
         INDEX_CDNA ( BLAT_CDNA.out.filtered_set )
         ch_versions = ch_versions.mix(INDEX_CDNA.out.versions)
-        MAP_CDNA (  trna_reads, INDEX_CDNA.out.bt_indices, 'cDNA' )
+        MAP_CDNA (  trna_reads, INDEX_CDNA.out.index, 'cDNA' )
         ch_versions = ch_versions.mix(MAP_CDNA.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_CDNA.out.stats.ifEmpty(null))
         MAP_CDNA.out.unmapped.set { cdna_reads }
@@ -88,7 +88,7 @@ workflow CONTAMINANT_FILTER {
         ch_versions = ch_versions.mix(BLAT_NCRNA.out.versions)
         INDEX_NCRNA ( BLAT_NCRNA.out.filtered_set )
         ch_versions = ch_versions.mix(INDEX_NCRNA.out.versions)
-        MAP_NCRNA ( cdna_reads, INDEX_NCRNA.out.bt_indices, 'ncRNA' )
+        MAP_NCRNA ( cdna_reads, INDEX_NCRNA.out.index, 'ncRNA' )
         ch_versions = ch_versions.mix(MAP_NCRNA.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_NCRNA.out.stats.ifEmpty(null))
         MAP_NCRNA.out.unmapped.set { ncrna_reads }
@@ -101,7 +101,7 @@ workflow CONTAMINANT_FILTER {
         ch_versions = ch_versions.mix(BLAT_PIRNA.out.versions)
         INDEX_PIRNA ( BLAT_PIRNA.out.filtered_set )
         ch_versions = ch_versions.mix(INDEX_PIRNA.out.versions)
-        MAP_PIRNA (ncrna_reads, INDEX_PIRNA.out.bt_indices, 'piRNA' )
+        MAP_PIRNA (ncrna_reads, INDEX_PIRNA.out.index, 'piRNA' )
         ch_versions = ch_versions.mix(MAP_PIRNA.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_PIRNA.out.stats.ifEmpty(null))
         MAP_PIRNA.out.unmapped.set { pirna_reads }
@@ -114,7 +114,7 @@ workflow CONTAMINANT_FILTER {
         ch_versions = ch_versions.mix(BLAT_OTHER.out.versions)
         INDEX_OTHER ( BLAT_OTHER.out.filtered_set )
         ch_versions = ch_versions.mix(INDEX_OTHER.out.versions)
-        MAP_OTHER (ncrna_reads, INDEX_OTHER.out.bt_indices, 'other' )
+        MAP_OTHER (ncrna_reads, INDEX_OTHER.out.index, 'other' )
         ch_versions = ch_versions.mix(MAP_OTHER.out.versions)
         ch_filter_stats = ch_filter_stats.mix(MAP_OTHER.out.stats.ifEmpty(null))
         MAP_OTHER.out.unmapped.set { other_cont_reads }

--- a/subworkflows/local/mirdeep2.nf
+++ b/subworkflows/local/mirdeep2.nf
@@ -10,7 +10,7 @@ workflow MIRDEEP2 {
     take:
     reads        // channel: [ val(meta), [ reads ] ]
     fasta
-    indices
+    index
     hairpin
     mature
 
@@ -20,7 +20,7 @@ workflow MIRDEEP2 {
     MIRDEEP2_PIGZ ( reads )
     ch_versions = ch_versions.mix(MIRDEEP2_PIGZ.out.versions.first())
 
-    MIRDEEP2_MAPPER ( MIRDEEP2_PIGZ.out.reads, indices )
+    MIRDEEP2_MAPPER ( MIRDEEP2_PIGZ.out.reads, index )
     ch_versions = ch_versions.mix(MIRDEEP2_MAPPER.out.versions.first())
 
     MIRDEEP2_RUN ( fasta, MIRDEEP2_MAPPER.out.mirdeep2_inputs, hairpin, mature )

--- a/subworkflows/local/mirna_quant.nf
+++ b/subworkflows/local/mirna_quant.nf
@@ -45,10 +45,10 @@ workflow MIRNA_QUANT {
     FORMAT_HAIRPIN ( hairpin_parsed )
     ch_versions = ch_versions.mix(FORMAT_HAIRPIN.out.versions)
 
-    INDEX_MATURE ( FORMAT_MATURE.out.formatted_fasta ).bowtie_indices.set { mature_bowtie }
+    INDEX_MATURE ( FORMAT_MATURE.out.formatted_fasta ).index.set { mature_bowtie }
     ch_versions = ch_versions.mix(INDEX_MATURE.out.versions)
 
-    INDEX_HAIRPIN ( FORMAT_HAIRPIN.out.formatted_fasta ).bowtie_indices.set { hairpin_bowtie }
+    INDEX_HAIRPIN ( FORMAT_HAIRPIN.out.formatted_fasta ).index.set { hairpin_bowtie }
     ch_versions = ch_versions.mix(INDEX_HAIRPIN.out.versions)
 
     reads

--- a/subworkflows/local/mirna_quant.nf
+++ b/subworkflows/local/mirna_quant.nf
@@ -64,7 +64,6 @@ workflow MIRNA_QUANT {
         .dump (tag:'hsux')
         .set { reads_hairpin }
 
-
     BOWTIE_MAP_HAIRPIN ( reads_hairpin, hairpin_bowtie.collect() )
     ch_versions = ch_versions.mix(BOWTIE_MAP_HAIRPIN.out.versions)
 
@@ -93,8 +92,10 @@ workflow MIRNA_QUANT {
     BOWTIE_MAP_SEQCLUSTER ( reads_collapsed, hairpin_bowtie.collect() )
     ch_versions = ch_versions.mix(BOWTIE_MAP_SEQCLUSTER.out.versions)
 
+    ch_mirtop_logs = Channel.empty()
     if (params.mirtrace_species){
         MIRTOP_QUANT ( BOWTIE_MAP_SEQCLUSTER.out.bam.collect{it[1]}, FORMAT_HAIRPIN.out.formatted_fasta, gtf )
+        ch_mirtop_logs = MIRTOP_QUANT.out.logs
         ch_versions = ch_versions.mix(MIRTOP_QUANT.out.versions)
 
         TABLE_MERGE ( MIRTOP_QUANT.out.mirtop_table )
@@ -109,22 +110,16 @@ workflow MIRNA_QUANT {
     fasta_mature        = FORMAT_MATURE.out.formatted_fasta
     fasta_hairpin       = FORMAT_HAIRPIN.out.formatted_fasta
     unmapped            = reads_genome
-    bowtie_versions     = BOWTIE_MAP_MATURE.out.versions
-    samtools_versions   = BAM_STATS_MATURE.out.versions
-    seqcluster_versions = SEQCLUSTER_SEQUENCES.out.versions
-    mirtop_versions     = MIRTOP_QUANT.out.versions
     mature_stats        = BAM_STATS_MATURE.out.stats
     hairpin_stats       = BAM_STATS_HAIRPIN.out.stats
-    mirtop_logs         = MIRTOP_QUANT.out.logs
-    merge_versions      = TABLE_MERGE.out.versions
+    mirtop_logs         = ch_mirtop_logs
 
     versions            = ch_versions
 }
 
-
 def add_suffix(row, suffix) {
     def meta = [:]
-    meta.id           = "${row[0].id}_${suffix}"
+    meta.id = "${row[0].id}_${suffix}"
     def array = []
     array = [ meta, row[1] ]
     return array


### PR DESCRIPTION
- Renamed `params.bowtie_indices` -> `params.bowtie_index` for consistency with other pipelines
- Renamed various namings for `*_indices` to `index` everywhere
- Initialised `params.fasta`, `params.mirtrace_species ` and `params.bowtie_index` in `main.nf` instead of `smrnaseq.nf` so their values are resolved properly when using a config file
- Removed `params.filter_species` and used logic locally in processes to determine which database to use (can be improved by providing this value as an `input` channel but it's ok for now)
- Fixed incorrect definition for parameter values in `nextflow.config` / `nextflow_schema.json`