### PR TITLE
More flexible samplesheet handling

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -55,55 +55,45 @@ def check_samplesheet(file_in, file_out):
         MIN_COLS = 2
         HEADER = ["sample", "fastq_1"]
         header = [x.strip('"') for x in fin.readline().strip().split(",")]
-        if header[: len(HEADER)] != HEADER:
-            print("ERROR: Please check samplesheet header -> {} != {}".format(",".join(header), ",".join(HEADER)))
+        if any([item not in header for item in HEADER]):
+            missing = [item for item in HEADER if item not in header]
+            eprint("ERROR: Please check samplesheet header. Missing columns: '{}'".format(",".join(missing)))
             sys.exit(1)
 
         ## Check sample entries
-        for line in fin:
+        for line_number, line in enumerate(fin):
             lspl = [x.strip().strip('"') for x in line.strip().split(",")]
+            row = {k: v for k, v in zip(header, lspl)}
 
             # Check valid number of columns per row
-            if len(lspl) < len(HEADER):
+            if len(lspl) != len(header):
                 print_error(
-                    "Invalid number of columns (minimum = {})!".format(len(HEADER)),
-                    "Line",
-                    line,
-                )
-            num_cols = len([x for x in lspl if x])
-            if num_cols < MIN_COLS:
-                print_error(
-                    "Invalid number of populated columns (minimum = {})!".format(MIN_COLS),
-                    "Line",
+                    "Invalid number of columns: found {} columns (header has {})".format(
+                        line_number, len(lspl), len(header)
+                    ),
+                    f"Line #{line_number+2}",
                     line,
                 )
 
             ## Check sample name entries
-            sample, fastq_1 = lspl[: len(HEADER)]
-            sample = sample.replace(" ", "_")
+            sample = row.get("sample", "").replace(" ", "_")
             if not sample:
-                print_error("Sample entry has not been specified!", "Line", line)
+                print_error("Sample entry has not been specified!", f"Line #{line_number+2}", line)
 
             ## Check FastQ file extension
-            for fastq in [fastq_1]:
-                if fastq:
-                    if fastq.find(" ") != -1:
-                        print_error("FastQ file contains spaces!", "Line", line)
-                    if not fastq.endswith(".fastq.gz") and not fastq.endswith(".fq.gz"):
-                        print_error(
-                            "FastQ file does not have extension '.fastq.gz' or '.fq.gz'!",
-                            "Line",
-                            line,
-                        )
+            fastq = row.get("fastq_1", None)
+            if fastq:
+                if fastq.find(" ") != -1:
+                    print_error("FastQ file contains spaces!", f"Line #{line_number+2}", line)
+                if not fastq.endswith(".fastq.gz") and not fastq.endswith(".fq.gz"):
+                    print_error(
+                        "FastQ file does not have extension '.fastq.gz' or '.fq.gz'!",
+                        "Line",
+                        line,
+                    )
 
-            ## Auto-detect paired-end/single-end
-            sample_info = []  ## [single_end, fastq_1, fastq_2]
-            if sample and fastq_1:  ## Single-end short reads
-                sample_info = ["1", fastq_1]
-            else:
-                print_error("Invalid combination of columns provided!", "Line", line)
-
-            ## Create sample mapping dictionary = { sample: [ single_end, fastq_1 ] }
+            ## Create sample mapping dictionary
+            sample_info = {"single_end": "1", "fastq_1": fastq}
             if sample not in sample_mapping_dict:
                 sample_mapping_dict[sample] = [sample_info]
             else:
@@ -113,19 +103,17 @@ def check_samplesheet(file_in, file_out):
                     sample_mapping_dict[sample].append(sample_info)
 
     ## Write validated samplesheet with appropriate columns
+    output_cols = ["id", "intrasample_id", "single_end", "fastq_1"]
     if len(sample_mapping_dict) > 0:
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            fout.write(",".join(["sample", "single_end", "fastq_1"]) + "\n")
+            fout.write(",".join(output_cols) + "\n")
             for sample in sorted(sample_mapping_dict.keys()):
-
-                ## Check that multiple runs of the same sample are of the same datatype
-                if not all(x[0] == sample_mapping_dict[sample][0][0] for x in sample_mapping_dict[sample]):
-                    print_error("Multiple runs of a sample must be of the same datatype!", "Sample: {}".format(sample))
-
-                for idx, val in enumerate(sample_mapping_dict[sample]):
-                    fout.write(",".join(["{}_T{}".format(sample, idx + 1)] + val) + "\n")
+                for intrasample_id, val in enumerate(sample_mapping_dict[sample]):
+                    sample_info = {**{"id": sample, "intrasample_id": str(intrasample_id)}, **val}
+                    outrow = [sample_info.get(colname, None) for colname in output_cols]
+                    fout.write(",".join(outrow) + "\n")
     else:
         print_error("No entries to process!", "Samplesheet: {}".format(file_in))
 

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -20,16 +20,11 @@ workflow INPUT_CHECK {
     versions = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }
 
-// Function to get list of [ meta, [ fastq_1, fastq_2 ] ]
+// Function to get list of [ meta, [ fastq_1 ] ]
 def create_fastq_channel(LinkedHashMap row) {
-    // create meta map
-    def meta = [:]
-    meta.id           = row.sample
-    meta.single_end   = 1
-    def array = []
+    def meta = row.findAll {it.key != "fastq_1"}
     if (!file(row.fastq_1).exists()) {
         exit 1, "ERROR: Please check input samplesheet -> Read 1 FastQ file does not exist!\n${row.fastq_1}"
     }
-    array = [ meta, [ file(row.fastq_1) ] ]
-    return array
+    return [ meta, [ file(row.fastq_1) ] ]
 }

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -98,12 +98,6 @@ workflow SMRNASEQ {
         ch_input
     )
     .reads
-    .map {
-        meta, fastq ->
-            meta.id = meta.id.split('_')[0..-2].join('_')
-            [ meta, fastq ] }
-    .dump(tag: 'map')
-    .groupTuple(by: [0])
     .dump(tag: 'group')
     .branch {
         meta, fastq ->


### PR DESCRIPTION
In preparation for handling adapter sequences in the samplesheet, we now pass through all columns in the samplesheet as keys in the meta map.

The commit also removes a bunch of redundant fastq_2 checking which we don't use.

<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
