### PR TITLE
FASTP fix

### DIFF
--- a/subworkflows/nf-core/fastqc_fastp.nf
+++ b/subworkflows/nf-core/fastqc_fastp.nf
@@ -28,7 +28,7 @@ String getFastpAdapterSequence(json_file){
 workflow FASTQC_FASTP {
     take:
     reads             // channel: [ val(meta), [ reads ] ]
-    adapter_list      // String [path/to/adapters.fa]
+    adapter_list      // channel: [ path/to/adapters.fa ]
     save_trimmed_fail //   value: boolean
     save_merged       //   value: boolean
 

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -38,7 +38,7 @@ ch_multiqc_config          = Channel.fromPath("$projectDir/assets/multiqc_config
 ch_multiqc_custom_config   = params.multiqc_config ? Channel.fromPath( params.multiqc_config, checkIfExists: true ) : Channel.empty()
 ch_multiqc_logo            = params.multiqc_logo   ? Channel.fromPath( params.multiqc_logo, checkIfExists: true ) : Channel.empty()
 ch_multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
-ch_fastp_adapters          = Channel.fromPath(params.fastp_known_mirna_adapters, checkIfExists: true)
+ch_fastp_adapters          = Channel.fromPath(params.fastp_known_mirna_adapters, checkIfExists: true).collect() // collect to consume for all incoming samples to FASTP
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,7 +150,7 @@ workflow SMRNASEQ {
 
     } else{
         //TODO - rob? :-)
-        
+
     }
 
 


### PR DESCRIPTION
The dev workflow was only running `FASTQC_FASTP:FASTP` for one sample:

```console
[cd/f06d74] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:INDEX_GENOME (grch37.fa)
[59/d070ca] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:INPUT_CHECK:SAMPLESHEET_CHECK (samplesheet.csv)
[18/fa206d] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:PARSE_HAIRPIN
[7e/4d67ff] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:PARSE_MATURE
[68/d0fd2e] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Clone9_N3)
[70/a5fc86] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Control_N1)
[a1/0aee71] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Clone9_N1)
[4d/5c41d2] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Clone9_N2)
[12/5af082] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Clone1_N3)
[a7/a6a80e] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Control_N2)
[ce/782518] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Control_N3)
[80/66b034] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTP (Clone1_N1)   👈🏼 👈🏼 👈🏼 
[05/be6fda] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:FORMAT_HAIRPIN (hairpin.fa_igenome.fa)
[23/d4c179] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:FORMAT_MATURE (mature.fa_igenome.fa)
[27/40b598] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_RAW (Clone1_N1)
[9d/ad46cc] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:INDEX_HAIRPIN
[e2/00e840] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:INDEX_MATURE
[0b/730d90] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:FASTQC_FASTP:FASTQC_TRIM (Clone1_N1)
[60/14ad68] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRDEEP2:MIRDEEP2_PIGZ (Clone1_N1)
[5f/c8417a] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:SEQCLUSTER_SEQUENCES (Clone1_N1_seqcluster)
[39/87bba5] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRTRACE:MIRTRACE_RUN
[86/a4c3a3] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BOWTIE_MAP_MATURE (Clone1_N1_mature)
[ad/2341b0] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BOWTIE_MAP_SEQCLUSTER (Clone1_N1_seqcluster)
[8c/33afbf] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:MIRTOP_QUANT
[93/d0eb7f] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BOWTIE_MAP_HAIRPIN (Clone1_N1_mature_hairpin)
[e3/717332] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_MATURE:SAMTOOLS_SORT (Clone1_N1_mature)
[8b/9d7a0f] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:TABLE_MERGE
[f7/20e40e] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_MATURE:SAMTOOLS_INDEX (Clone1_N1_mature)
[5a/513951] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_MATURE:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (Clone1_N1_mature)
[94/727e48] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_MATURE:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (Clone1_N1_mature)
[1f/011d0c] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_MATURE:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (Clone1_N1_mature)
[7f/65a14c] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_HAIRPIN:SAMTOOLS_SORT (Clone1_N1_mature_hairpin)
[e8/e83098] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_HAIRPIN:SAMTOOLS_INDEX (Clone1_N1_mature_hairpin)
[9d/7b14da] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_HAIRPIN:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (Clone1_N1_mature_hairpin)
[c8/b0a252] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_HAIRPIN:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (Clone1_N1_mature_hairpin)
[be/f4bab4] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:BAM_STATS_HAIRPIN:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (Clone1_N1_mature_hairpin)
[2d/680138] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRNA_QUANT:EDGER_QC
[94/7104d5] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRDEEP2:MIRDEEP2_MAPPER (Clone1_N1)
[55/ae5aa4] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BOWTIE_MAP_GENOME (Clone1_N1_mature_hairpin_genome)
[54/1a6fe1] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MIRDEEP2:MIRDEEP2_RUN (1)
[31/f74725] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:SAMTOOLS_SORT (Clone1_N1_mature_hairpin_genome)
[15/756155] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:SAMTOOLS_INDEX (Clone1_N1_mature_hairpin_genome)
[80/40bf0c] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (Clone1_N1_mature_hairpin_genome)
[b4/47ff3e] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:GENOME_QUANT:BAM_SORT_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (Clone1_N1_mature_hairpin_genome)
[93/895b7a] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:CUSTOM_DUMPSOFTWAREVERSIONS (1)
Pulling Singularity image https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0 [cache /data/containers/depot.galaxyproject.org-singularity-multiqc-1.14--pyhdfd78af_0.img]
[ef/9ff82a] Submitted process > NFCORE_SMRNASEQ:SMRNASEQ:MULTIQC
-[nf-core/smrnaseq] Pipeline completed successfully-
```

Use collect on the fastp adapters 😄 