### PR TITLE
Fixed an issue where miRTrace reports fastq basename instead of sample ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Dev
 
+- [[#220](https://github.com/nf-core/smrnaseq/issues/220)] - Fixed an issue where miRTrace reports fastq basename instead of sample ID
 - [[#208](https://github.com/nf-core/smrnaseq/issues/208)] - Fixed usability of `--skip_qc` parameter
 - Updated FASTP module to allow direct addition of adapter_fasta file to it
 - [[#205](https://github.com/nf-core/smrnaseq/issues/205)] - Fix mirTrace Report to be a single report again instead of per sample reports

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -21,6 +21,7 @@ process MIRTRACE_RUN {
     def primer = meta.adapter ? "--adapter ${meta.adapter}" : ""
     def protocol = params.protocol == 'custom' ? '' : "--protocol $params.protocol"
     def java_mem = ''
+    def prefix = "${meta.id}"
     if(task.memory){
         tmem = task.memory.toBytes()
         java_mem = "-Xms${tmem} -Xmx${tmem}"
@@ -30,7 +31,7 @@ process MIRTRACE_RUN {
     for i in $reads
     do
         path=\$(realpath \${i})
-        prefix=\$(echo \${i} | sed -e 's/.gz//' -e 's/.fastq//' -e 's/.fq//' -e 's/_val_1//' -e 's/_trimmed//' -e 's/_R1//' -e 's/.R1//')
+        prefix=$prefix
         echo \$path","\$prefix
     done > mirtrace_config
 


### PR DESCRIPTION
<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.

The mirTrace module was using a series of regexes to pull out the fastq basename as a sample ID, rather than using $meta.id as for other tools in the pipeline