### PR TITLE
Skipqc fix and group samples by adapter for mirtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.2.0](https://github.com/nf-core/smrnaseq/releases/tag/2.2.0) - 2023-04-25
+## [v2.2.0](https://github.com/nf-core/smrnaseq/releases/tag/2.2.0) - 2023-04-26
 
 - [[#220](https://github.com/nf-core/smrnaseq/issues/220)] - Fixed an issue where miRTrace reports fastq basename instead of sample ID
 - [[#208](https://github.com/nf-core/smrnaseq/issues/208)] - Fixed usability of `--skip_qc` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- Group samples by adapter sequence before running mirtrace.
-
 ## [v2.2.0](https://github.com/nf-core/smrnaseq/releases/tag/2.2.0) - 2023-04-25
 
 - [[#220](https://github.com/nf-core/smrnaseq/issues/220)] - Fixed an issue where miRTrace reports fastq basename instead of sample ID
@@ -13,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#205](https://github.com/nf-core/smrnaseq/issues/205)] - Fix mirTrace Report to be a single report again instead of per sample reports
 - [[#206](https://github.com/nf-core/smrnaseq/issues/206)] - Use % as separator in sed commands to enable conda working properly on OSX and Linux
 - [[#207](https://github.com/nf-core/smrnaseq/issues/224)] - Fix Samplesheet print error
+- Group samples by adapter sequence before running mirtrace
 
 ## [v2.1.0](https://github.com/nf-core/smrnaseq/releases/tag/2.1.0) - 2022-10-20 Maroon Tin Dalmatian
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#206](https://github.com/nf-core/smrnaseq/issues/206)] - Use % as separator in sed commands to enable conda working properly on OSX and Linux
 - [[#207](https://github.com/nf-core/smrnaseq/issues/224)] - Fix Samplesheet print error
 - Group samples by adapter sequence before running mirtrace
+- Remove `--skip_qc` parameter
 
 ## [v2.1.0](https://github.com/nf-core/smrnaseq/releases/tag/2.1.0) - 2022-10-20 Maroon Tin Dalmatian
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Group samples by adapter sequence before running mirtrace.
+
 ## [v2.2.0](https://github.com/nf-core/smrnaseq/releases/tag/2.2.0) - 2023-04-25
 
 - [[#220](https://github.com/nf-core/smrnaseq/issues/220)] - Fixed an issue where miRTrace reports fastq basename instead of sample ID

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -87,7 +87,7 @@ process {
     }
 }
 
-if (!(params.skip_fastqc || params.skip_qc)) {
+if (!(params.skip_fastqc)) {
     process {
         withName: '.*:FASTQC_FASTP:FASTQC_.*' {
             ext.args = '--quiet'

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -30,7 +30,7 @@ process MIRTRACE_RUN {
     .collect({ id, path -> "echo '${path},${id}' >> mirtrace_config" })
     """
     export mirtracejar=\$(dirname \$(which mirtrace))
-    
+
     ${config_lines.join("\n    ")}
 
     java $java_mem -jar \$mirtracejar/mirtrace.jar --mirtrace-wrapper-name mirtrace qc  \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,6 @@ params {
     fastp_min_length            = 17
     fastp_known_mirna_adapters  = "$projectDir/assets/known_adapters.fa"
     save_trimmed_fail           = false
-    skip_qc                     = false
     skip_fastqc                 = false
     skip_multiqc                = false
     skip_mirdeep                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -249,11 +249,6 @@
             "description": "Switches to skip specific pipeline steps, if desired.",
             "fa_icon": "fas fa-fast-forward",
             "properties": {
-                "skip_qc": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-fast-forward",
-                    "description": "Skip all QC steps"
-                },
                 "skip_fastqc": {
                     "type": "boolean",
                     "fa_icon": "fas fa-fast-forward",

--- a/subworkflows/local/fastqc_fastp.nf
+++ b/subworkflows/local/fastqc_fastp.nf
@@ -35,10 +35,10 @@ workflow FASTQC_FASTP {
 
     main:
 
-    ch_versions = Channel.empty()
-
+    ch_versions     = Channel.empty()
     fastqc_raw_html = Channel.empty()
     fastqc_raw_zip  = Channel.empty()
+    adapterseq      = reads.map { meta, _ -> [meta, null] }
     if (!params.skip_fastqc) {
         FASTQC_RAW (
             reads

--- a/subworkflows/local/mirtrace.nf
+++ b/subworkflows/local/mirtrace.nf
@@ -6,10 +6,11 @@ include { MIRTRACE_RUN } from '../../modules/local/mirtrace'
 
 workflow MIRTRACE {
     take:
-    reads      // channel: [ val(meta), [ reads ] ]
+    reads      // channel: [ val(adapterseq), [ val(ids) ], [ path(reads) ] ]
 
     main:
     reads
+    | map { adapterseq, ids, read_collection -> [adapterseq, ids, read_collection*.first()]}
     | MIRTRACE_RUN
 
     emit:

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -125,7 +125,6 @@ workflow SMRNASEQ {
     // SUBWORKFLOW: Read QC and trim adapters
     //
 
-    if(!params.skip_qc){
     FASTQC_FASTP (
         ch_cat_fastq,
         ch_fastp_adapters,
@@ -133,27 +132,20 @@ workflow SMRNASEQ {
         false
     )
     ch_versions = ch_versions.mix(FASTQC_FASTP.out.versions)
-    reads_for_mirna = FASTQC_FASTP.out.reads
-
+    ch_reads = FASTQC_FASTP.out.reads
 
     //
     // SUBWORKFLOW: mirtrace QC
     //
-    ch_outputs_for_mirtrace = FASTQC_FASTP.out.adapterseq
+    FASTQC_FASTP.out.adapterseq
     .join( ch_cat_fastq )
     .map { meta, adapterseq, fastq -> [meta + [adapter:adapterseq], fastq] }
     .collect()
+    .set { ch_mitrace_inputs }
 
-    MIRTRACE(ch_outputs_for_mirtrace)
 
+    MIRTRACE(ch_mitrace_inputs)
     ch_versions = ch_versions.mix(MIRTRACE.out.versions.ifEmpty(null))
-
-    } else{
-        //TODO - rob? :-)
-
-    }
-
-
 
 
     //
@@ -172,10 +164,8 @@ workflow SMRNASEQ {
             FASTQC_FASTP.out.reads
         )
 
-        reads_for_mirna = CONTAMINANT_FILTER.out.filtered_reads
+        contamination_stats = CONTAMINANT_FILTER.out.filter_stats
         ch_versions = ch_versions.mix(CONTAMINANT_FILTER.out.versions)
-        CONTAMINANT_FILTER.out.filter_stats
-            .set { contamination_stats }
 
     }
 
@@ -183,7 +173,7 @@ workflow SMRNASEQ {
         reference_mature,
         reference_hairpin,
         mirna_gtf,
-        reads_for_mirna
+        CONTAMINANT_FILTER.out.filtered_reads
     )
     ch_versions = ch_versions.mix(MIRNA_QUANT.out.versions.ifEmpty(null))
 
@@ -229,9 +219,8 @@ workflow SMRNASEQ {
         ch_multiqc_files = Channel.empty()
         ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
         ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-
-        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_FASTP.out.fastqc_raw_zip.collect{it[1]}.ifEmpty([])),
-        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_FASTP.out.trim_json.collect{it[1]}.ifEmpty([])),
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_FASTP.out.fastqc_raw_zip.collect{it[1]}.ifEmpty([]))
+        ch_multiqc_files = ch_multiqc_files.mix(FASTQC_FASTP.out.trim_json.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(contamination_stats.collect().ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(MIRNA_QUANT.out.mature_stats.collect({it[1]}).ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(MIRNA_QUANT.out.hairpin_stats.collect({it[1]}).ifEmpty([]))
@@ -239,13 +228,13 @@ workflow SMRNASEQ {
         ch_multiqc_files = ch_multiqc_files.mix(MIRNA_QUANT.out.mirtop_logs.collect().ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(MIRTRACE.out.results.collect().ifEmpty([]))
 
-    MULTIQC (
-        ch_multiqc_files.collect(),
-        ch_multiqc_config.toList(),
-        ch_multiqc_custom_config.toList(),
-        ch_multiqc_logo.toList()
-    )
-    multiqc_report = MULTIQC.out.report.toList()
+        MULTIQC (
+            ch_multiqc_files.collect(),
+            ch_multiqc_config.toList(),
+            ch_multiqc_custom_config.toList(),
+            ch_multiqc_logo.toList()
+        )
+        multiqc_report = MULTIQC.out.report.toList()
     }
 }
 

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -59,7 +59,7 @@ if (!params.mirgenedb) {
 }
 
 include { INPUT_CHECK        } from '../subworkflows/local/input_check'
-include { FASTQC_FASTP       } from '../subworkflows/nf-core/fastqc_fastp'
+include { FASTQC_FASTP       } from '../subworkflows/local/fastqc_fastp'
 include { CONTAMINANT_FILTER } from '../subworkflows/local/contaminant_filter'
 include { MIRNA_QUANT        } from '../subworkflows/local/mirna_quant'
 include { GENOME_QUANT       } from '../subworkflows/local/genome_quant'
@@ -132,7 +132,6 @@ workflow SMRNASEQ {
         false
     )
     ch_versions = ch_versions.mix(FASTQC_FASTP.out.versions)
-    ch_reads = FASTQC_FASTP.out.reads
 
     //
     // SUBWORKFLOW: mirtrace QC


### PR DESCRIPTION
The important changes here are the removal of the skip_qc parameter (skip_fastp is still intact), and the more complicated work of running mirtrace more carefully.

The workflow can accomodate samples that use different adapter sequences, auto-detected by FastP. Unfortunately, each run of mitrace assumes a single adapter, so here we group samples by adapter and run mirtrace in batches by adapter. The grouping is helpful to ensure that samples that share an adapter can be grouped in the MultiQC report.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
