### PR TITLE
Remove glob from process definition when using ECR container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Current dev
 
-- Remove globs from process alias when using ECR containers
+- [[#253]](https://github.com/nf-core/smrnaseq/pull/253) - Remove globs from process alias when using ECR containers
 
 ## [v2.2.1](https://github.com/nf-core/smrnaseq/releases/tag/2.2.1) - 2023-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Current dev
 
-Nothing yet
+- Remove globs from process alias when using ECR containers
+
 ## [v2.2.1](https://github.com/nf-core/smrnaseq/releases/tag/2.2.1) - 2023-05-12
 
 ### Enhancements & fixes

--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -12,19 +12,19 @@ docker.registry = 'public.ecr.aws'
 podman.registry = 'public.ecr.aws'
 
 process {
-    withName: '.*:SAMPLESHEET_CHECK' {
+    withName: 'SAMPLESHEET_CHECK' {
         container = "quay.io/biocontainers/python:3.8.3"
     }
-    withName: '.*:BOWTIE_MAP.*' {
+    withName: 'BOWTIE_MAP' {
         container = 'quay.io/biocontainers/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837-0'
     }
-    withName: '.*:EDGER_QC' {
+    withName: 'EDGER_QC' {
         container = 'quay.io/biocontainers/mulled-v2-419bd7f10b2b902489ac63bbaafc7db76f8e0ae1:709335c37934db1b481054cbec637c6e5b5971cb-0'
     }
-    withName: '.*:MIRTOP_QUANT' {
+    withName: 'MIRTOP_QUANT' {
         container = 'quay.io/biocontainers/mulled-v2-0c13ef770dd7cc5c76c2ce23ba6669234cf03385:63be019f50581cc5dfe4fc0f73ae50f2d4d661f7-0'
     }
-    withName: '.*:TABLE_MERGE' {
+    withName: 'TABLE_MERGE' {
         container = 'quay.io/biocontainers/r-data.table:1.12.2'
     }
 }

--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -15,7 +15,7 @@ process {
     withName: 'SAMPLESHEET_CHECK' {
         container = "quay.io/biocontainers/python:3.8.3"
     }
-    withName: 'BOWTIE_MAP' {
+    withName: 'BOWTIE_MAP.*' {
         container = 'quay.io/biocontainers/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:40128b496751b037e2bd85f6789e83d4ff8a4837-0'
     }
     withName: 'EDGER_QC' {


### PR DESCRIPTION
Remove globs from process definitions in ECR containers so aliased modules.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
