### PR TITLE
Update Mirbase URLs structure to match their new structure

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,9 +26,9 @@ It should point to the 3-letter species name used by [miRBase](https://www.mirba
 
 Different parameters can be set for the two supported databases. By default `miRBase` will be used with the parameters below.
 
-- `mirna_gtf`: If not supplied by the user, then `mirna_gtf` will point to the latest GFF3 file in miRbase: `https://mirbase.org/ftp/CURRENT/genomes/${params.mirtrace_species}.gff3`
-- `mature`: points to the FASTA file of mature miRNA sequences. `https://mirbase.org/ftp/CURRENT/mature.fa.gz`
-- `hairpin`: points to the FASTA file of precursor miRNA sequences. `https://mirbase.org/ftp/CURRENT/hairpin.fa.gz`
+- `mirna_gtf`: If not supplied by the user, then `mirna_gtf` will point to the latest GFF3 file in miRbase: `https://mirbase.org/download/CURRENT/genomes/${params.mirtrace_species}.gff3`
+- `mature`: points to the FASTA file of mature miRNA sequences. `https://mirbase.org/download/CURRENT/mature.fa`
+- `hairpin`: points to the FASTA file of precursor miRNA sequences. `https://mirbase.org/download/CURRENT/hairpin.fa`
 
 If MirGeneDB should be used instead it needs to be specified using `--mirgenedb` and use the parameters below .
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,8 +20,8 @@ params {
     igenomes_base               = 's3://ngi-igenomes/igenomes'
     igenomes_ignore             = false
     mirna_gtf                   = null
-    mature                      = "https://mirbase.org/ftp/CURRENT/mature.fa.gz"
-    hairpin                     = "https://mirbase.org/ftp/CURRENT/hairpin.fa.gz"
+    mature                      = "https://mirbase.org/download/CURRENT/mature.fa"
+    hairpin                     = "https://mirbase.org/download/CURRENT/hairpin.fa"
     mirgenedb                   = false
     mirgenedb_mature            = null
     mirgenedb_hairpin           = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -87,7 +87,7 @@
                 "mirna_gtf": {
                     "type": "string",
                     "description": "GFF/GTF file with coordinates positions of precursor and miRNAs.",
-                    "help_text": "miRBase `.gff3` file, typically downloaded from [`https://mirbase.org/ftp/CURRENT/genomes/`](https://mirbase.org/ftp/CURRENT/genomes/)\n\nIf using iGenomes with `--genome` this file will be downloaded from miRBase automatically during the pipeline run.\n\n",
+                    "help_text": "miRBase `.gff3` file, typically downloaded from [`https://mirbase.org/download/CURRENT/genomes/`](https://mirbase.org/download/CURRENT/genomes/)\n\nIf using iGenomes with `--genome` this file will be downloaded from miRBase automatically during the pipeline run.\n\n",
                     "fa_icon": "fas fa-address-book"
                 },
                 "mirgenedb_gff": {
@@ -100,7 +100,7 @@
                     "description": "Path to FASTA file with mature miRNAs.",
                     "fa_icon": "fas fa-wheelchair",
                     "help_text": "Typically this will be the `mature.fa` file from miRBase. Can be given either as a plain text `.fa` file or a compressed `.gz` file.\n\nDefaults to the current miRBase release URL, from which the file will be downloaded.",
-                    "default": "https://mirbase.org/ftp/CURRENT/mature.fa.gz"
+                    "default": "https://mirbase.org/download/CURRENT/mature.fa"
                 },
                 "mirgenedb_mature": {
                     "type": "string",
@@ -112,7 +112,7 @@
                     "description": "Path to FASTA file with miRNAs precursors.",
                     "fa_icon": "fab fa-cuttlefish",
                     "help_text": "Typically this will be the `mature.fa` file from miRBase. Can be given either as a plain text `.fa` file or a compressed `.gz` file.\n\nDefaults to the current miRBase release URL, from which the file will be downloaded.",
-                    "default": "https://mirbase.org/ftp/CURRENT/hairpin.fa.gz"
+                    "default": "https://mirbase.org/download/CURRENT/hairpin.fa"
                 },
                 "mirgenedb_hairpin": {
                     "type": "string",

--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -25,7 +25,7 @@ if (!params.mirtrace_species) {
 }
 
 // Genome options
-def mirna_gtf_from_species = params.mirtrace_species ? "https://mirbase.org/ftp/CURRENT/genomes/${params.mirtrace_species}.gff3" : false
+def mirna_gtf_from_species = params.mirtrace_species ? "https://mirbase.org/download/CURRENT/genomes/${params.mirtrace_species}.gff3" : false
 def mirna_gtf = params.mirna_gtf ?: mirna_gtf_from_species
 
 /*


### PR DESCRIPTION
Mirbase has changed where they host genoms, hairpin and mature fasta files. 

Previously: `https://mirbase.org/ftp/CURRENT/mature.fa.gz`
Updated: `https://mirbase.org/download/CURRENT/mature.fa`

Note that Mirbase no longer hosts the compressed version of these files - only the uncompressed fa version.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
