### PR TITLE
Fix mirtrace staging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v2.3.1 - XXXX-XX-XX- Gray Zinc Dalmation Patch
 
 - [[#328]](https://github.com/nf-core/smrnaseq/pull/328) - Fix [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
-- [[#331]](https://github.com/nf-core/smrnaseq/pull/331) - Final fix for [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
+- [[#335]](https://github.com/nf-core/smrnaseq/pull/335) - Final fix for [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v2.3.1 - XXXX-XX-XX- Gray Zinc Dalmation Patch
 
 - [[#328]](https://github.com/nf-core/smrnaseq/pull/328) - Fix [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
+- [[#331]](https://github.com/nf-core/smrnaseq/pull/331) - Final fix for [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
 
 ### Software dependencies
 

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -8,6 +8,7 @@ process MIRTRACE_RUN {
 
     input:
     tuple val(adapter), val(ids), path(reads)
+    path(mirtrace_config)
 
     output:
     path "mirtrace/*"  , emit: mirtrace
@@ -26,13 +27,6 @@ process MIRTRACE_RUN {
         java_mem = "-Xms${tmem} -Xmx${tmem}"
     }
 
-    //Staging the files as path() but then getting the filenames for the config file that mirtrace needs
-    //Directly using val(reads) as in previous versions is not reliable as staging between work directories is not 100% reliable if not explicitly defined via nextflow itself
-    def config_lines = [ids,reads]
-    .transpose()
-    .collect({ id, path -> path.getFileName().toString()})
-    .map({path -> "echo ./${path}\n >> mirtrace_config"})
-
     """
     export mirtracejar=\$(dirname \$(which mirtrace))
 
@@ -40,7 +34,7 @@ process MIRTRACE_RUN {
         --species $params.mirtrace_species \\
         $primer \\
         $protocol \\
-        --config mirtrace_config \\
+        --config $mirtrace_config \\
         --write-fasta \\
         --output-dir mirtrace \\
         --force

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -31,11 +31,10 @@ process MIRTRACE_RUN {
     def config_lines = [ids,reads]
     .transpose()
     .collect({ id, path -> path.getFileName().toString()})
+    .map({path -> "echo ./${path}\n >> mirtrace_config"})
 
     """
     export mirtracejar=\$(dirname \$(which mirtrace))
-
-    ${config_lines.join("\n    ")}
 
     java $java_mem -jar \$mirtracejar/mirtrace.jar --mirtrace-wrapper-name mirtrace qc  \\
         --species $params.mirtrace_species \\

--- a/modules/local/mirtrace.nf
+++ b/modules/local/mirtrace.nf
@@ -7,7 +7,7 @@ process MIRTRACE_RUN {
         'biocontainers/mirtrace:1.0.1--hdfd78af_1' }"
 
     input:
-    tuple val(adapter), val(ids), val(reads)
+    tuple val(adapter), val(ids), path(reads)
 
     output:
     path "mirtrace/*"  , emit: mirtrace
@@ -25,9 +25,13 @@ process MIRTRACE_RUN {
         tmem = task.memory.toBytes()
         java_mem = "-Xms${tmem} -Xmx${tmem}"
     }
+
+    //Staging the files as path() but then getting the filenames for the config file that mirtrace needs
+    //Directly using val(reads) as in previous versions is not reliable as staging between work directories is not 100% reliable if not explicitly defined via nextflow itself
     def config_lines = [ids,reads]
     .transpose()
-    .collect({ id, path -> "echo '${path},${id}' >> mirtrace_config" })
+    .collect({ id, path -> path.getFileName().toString()})
+
     """
     export mirtracejar=\$(dirname \$(which mirtrace))
 

--- a/subworkflows/local/mirtrace.nf
+++ b/subworkflows/local/mirtrace.nf
@@ -9,7 +9,18 @@ workflow MIRTRACE {
     reads      // channel: [ val(adapterseq), [ val(ids) ], [ path(reads) ] ]
 
     main:
-    reads | MIRTRACE_RUN
+
+    //Staging the files as path() but then getting the filenames for the config file that mirtrace needs
+    //Directly using val(reads) as in previous versions is not reliable as staging between work directories is not 100% reliable if not explicitly defined via nextflow itself
+    ch_mirtrace_config =
+    reads.map { adapter, ids, reads -> [ids,reads]}
+    .transpose()
+    .collectFile { id, path -> "./${path.getFileName().toString()}\n" } // operations need a channel, so, should be outside the module
+
+    MIRTRACE_RUN (
+        reads,
+        ch_mirtrace_config
+    )
 
     emit:
     results    = MIRTRACE_RUN.out.mirtrace


### PR DESCRIPTION
This addresses the staging / casting issue first identified in the issue https://github.com/nf-core/smrnaseq/issues/327

The previous fix ignored the possibility that (depending on the platform), directly referencing work directories can cause trouble as there is no guarantee that these are staged properly to the work dir of mirtrace. This is resolved by reverting to the previously working approach with mirtrace where the files are staged  to the same directory, then adding functionality to use the filename(s) of provided files in the work dir of mirtrace directly instead. This ensures nextflow is aware of any files being staged to mirtrace, thus guaranteeing that files are properly staged. 


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
