### PR TITLE
Fix auto-detection of adapter with fastp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#334]](https://github.com/nf-core/smrnaseq/pull/334) - Fix [input channel cardinality](https://github.com/nf-core/smrnaseq/issues/331) in `MIRDEEP2_RUN` module
 - [[#334]](https://github.com/nf-core/smrnaseq/pull/334) - Fix [bowtie conda version](https://github.com/nf-core/smrnaseq/issues/333) in `BOWTIE_MAP_SEQ` module
 - [[#335]](https://github.com/nf-core/smrnaseq/pull/335) - Final fix for [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
+- [[#337]](https://github.com/nf-core/smrnaseq/pull/337) - Fix [three_prime_adapter issue](https://github.com/nf-core/smrnaseq/issues/327), allow `auto-detect` as value
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#334]](https://github.com/nf-core/smrnaseq/pull/334) - Fix [input channel cardinality](https://github.com/nf-core/smrnaseq/issues/331) in `MIRDEEP2_RUN` module
 - [[#334]](https://github.com/nf-core/smrnaseq/pull/334) - Fix [bowtie conda version](https://github.com/nf-core/smrnaseq/issues/333) in `BOWTIE_MAP_SEQ` module
 - [[#335]](https://github.com/nf-core/smrnaseq/pull/335) - Final fix for [casting issue](https://github.com/nf-core/smrnaseq/issues/327) in mirtrace module
-- [[#337]](https://github.com/nf-core/smrnaseq/pull/337) - Fix [three_prime_adapter issue](https://github.com/nf-core/smrnaseq/issues/327), allow `auto-detect` as value
+- [[#337]](https://github.com/nf-core/smrnaseq/pull/337) - Fix [three_prime_adapter issue](https://github.com/nf-core/smrnaseq/issues/326), allow `auto-detect` as value
 
 ### Software dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -47,12 +47,12 @@ process {
     //
     withName: '.*:FASTQ_FASTQC_UMITOOLS_FASTP:FASTP' {
         ext.args = [ "",
-            params.trim_fastq                  ? "" : "--disable_adapter_trimming",
-            params.clip_r1 > 0                 ? "--trim_front1 ${params.clip_r1}" : "", // Remove bp from the 5' end of read 1.
-            params.three_prime_clip_r1 > 0     ? "--trim_tail1 ${params.three_prime_clip_r1}" : "", // Remove bp from the 3' end of read 1 AFTER adapter/quality trimming has been performed.
-            params.fastp_min_length > 0        ? "-l ${params.fastp_min_length}" : "",
-            params.fastp_max_length > 0        ? "--max_len1 ${params.fastp_max_length}" : "",
-            params.three_prime_adapter == null ?  '' : "--adapter_sequence ${params.three_prime_adapter}"
+            params.trim_fastq                           ? "" : "--disable_adapter_trimming",
+            params.clip_r1 > 0                          ? "--trim_front1 ${params.clip_r1}" : "", // Remove bp from the 5' end of read 1.
+            params.three_prime_clip_r1 > 0              ? "--trim_tail1 ${params.three_prime_clip_r1}" : "", // Remove bp from the 3' end of read 1 AFTER adapter/quality trimming has been performed.
+            params.fastp_min_length > 0                 ? "-l ${params.fastp_min_length}" : "",
+            params.fastp_max_length > 0                 ? "--max_len1 ${params.fastp_max_length}" : "",
+            params.three_prime_adapter == "auto-detect" ?  "" : "--adapter_sequence ${params.three_prime_adapter}"
         ].join(" ").trim()
         publishDir = [
             [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ This option indicates the experimental protocol used for the sample preparation.
 
 The parameter `--three_prime_adapter` is set to the Illumina TruSeq single index adapter sequence `AGATCGGAAGAGCACACGTCTGAACTCCAGTCA`. This is also to ensure, that the auto-detect functionality of `FASTP` is disabled. Please make sure to adapt this adapter sequence accordingly for your run.
 
-:warning: At least the `custom` protocol has to be specified, otherwise the pipeline won't run. In case you specify the `custom` protocol, ensure that the parameters above are set accordingly or the defaults will be applied. If you want to auto-detect the adapters using `fastp`, please set `--three_prime_adapter` to `""`.
+:warning: At least the `custom` protocol has to be specified, otherwise the pipeline won't run. In case you specify the `custom` protocol, ensure that the parameters above are set accordingly or the defaults will be applied. If you want to auto-detect the adapters using `fastp`, please set `--three_prime_adapter` to `auto-detect`.
 
 ### `mirtrace_species` or `mirgenedb_species`
 


### PR DESCRIPTION
Fixes #326. 

With this change it is possible to enable `fastp` adapter auto-detection using the parameter value "auto-detect".  

<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
