### PR TITLE
Default test profile causes pipeline failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#349]](https://github.com/nf-core/smrnaseq/pull/349) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), change conda-base to conda-forge channel
 - [[#350]](https://github.com/nf-core/smrnaseq/pull/350) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), set python version to 3.7 to fix pysam issue
 - [[#351]](https://github.com/nf-core/smrnaseq/issues/351) - Fix [Protocol inheritance issue](https://github.com/nf-core/smrnaseq/pull/364) - fixing protocol inheritance from subworkflow with move to config profile(s) for different protocols
+- [[#371]](https://github.com/nf-core/smrnaseq/issues/371) - Fix [Plain test profile](https://github.com/nf-core/smrnaseq/pull/372) - Updated default protocol value to "custom".
 
 ## v2.3.1 - 2024-04-18 - Gray Zinc Dalmation Patch
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     input                       = null
 
     // Protocol default (override via config profile - NOT directly via parameter!)
-    protocol                    = "Custom"
+    protocol                    = "custom"
 
     // References
     genome                      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -43,7 +43,7 @@
                 },
                 "protocol": {
                     "type": "string",
-                    "default": "Custom",
+                    "default": "custom",
                     "fa_icon": "fas fa-atom"
                 }
             }


### PR DESCRIPTION
<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

The PR addresses running the error that appears when running this command:
nextflow run ../../main.nf -profile test,docker --outdir results -resume

The issue is related to having the params protocol set to "Custom" while the MIRTRACE_RUN process expects "custom"

Related to this issue:
https://github.com/nf-core/smrnaseq/issues/371
https://github.com/nf-core/smrnaseq/issues/373

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
