### PR TITLE
Change profile configuration for CI tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - "test"
           - "test_no_genome"
           - "test_umi"
-          - "test_index"
+          - "test_index,illumina"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/smrnaseq') }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         NXF_VER:
           - "23.04.0"
@@ -30,7 +31,7 @@ jobs:
           - "test"
           - "test_no_genome"
           - "test_umi"
-          - "test_index,illumina"
+          - "test_index"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           - "23.04.0"
           - "latest-everything"
         profile:
-          - "test,illumina"
-          - "test_no_genome,illumina"
-          - "test_umi,illumina"
-          - "test_index,illumina"
+          - "test"
+          - "test_no_genome"
+          - "test_umi"
+          - "test_index"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#349]](https://github.com/nf-core/smrnaseq/pull/349) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), change conda-base to conda-forge channel
 - [[#350]](https://github.com/nf-core/smrnaseq/pull/350) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), set python version to 3.7 to fix pysam issue
 - [[#351]](https://github.com/nf-core/smrnaseq/issues/351) - Fix [Protocol inheritance issue](https://github.com/nf-core/smrnaseq/pull/364) - fixing protocol inheritance from subworkflow with move to config profile(s) for different protocols
+- [[#374]](https://github.com/nf-core/smrnaseq/pull/374) - Fix default tests so that they do not require additional profiles.
 
 ## v2.3.1 - 2024-04-18 - Gray Zinc Dalmation Patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#349]](https://github.com/nf-core/smrnaseq/pull/349) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), change conda-base to conda-forge channel
 - [[#350]](https://github.com/nf-core/smrnaseq/pull/350) - Fix [MIRTOP_QUANT conda issue](https://github.com/nf-core/smrnaseq/issues/347), set python version to 3.7 to fix pysam issue
 - [[#351]](https://github.com/nf-core/smrnaseq/issues/351) - Fix [Protocol inheritance issue](https://github.com/nf-core/smrnaseq/pull/364) - fixing protocol inheritance from subworkflow with move to config profile(s) for different protocols
-- [[#374]](https://github.com/nf-core/smrnaseq/pull/374) - Fix default tests so that they do not require additional profiles.
+- [[#374]](https://github.com/nf-core/smrnaseq/pull/374) - Fix [default tests](https://github.com/nf-core/smrnaseq/issues/375) so that they do not require additional profiles in CI. Change GitHub CI fail-fast strategy to false.
 - [[#371]](https://github.com/nf-core/smrnaseq/issues/371) - Fix [Plain test profile](https://github.com/nf-core/smrnaseq/pull/372) - Updated default protocol value to "custom".
 
 ## v2.3.1 - 2024-04-18 - Gray Zinc Dalmation Patch

--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ You can find numerous talks on the nf-core events page from various topics inclu
 > [!NOTE]
 > If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.
 
-First, prepare a samplesheet with your input data that looks as follows:
+You can test the pipeline as follows:
+
+```bash
+nextflow run nf-core/smrnaseq \
+   -profile test \
+  --outdir <OUTDIR>
+```
+
+In order to use the pipeline with your own data, first prepare a samplesheet with your input data that looks as follows:
 
 `samplesheet.csv`:
 
@@ -106,6 +114,9 @@ nextflow run nf-core/smrnaseq \
   --mirtrace_species 'hsa' \
   --outdir <OUTDIR>
 ```
+
+> [!IMPORTANT]
+> Remember to add a protocol as an additional profile (such as `illumina`, `nexttflex`, `qiaseq` or `custom`) when running with your own data. Default is `custom`. See [usage documentation](https://nf-co.re/smrnaseq/usage) for more details about these profiles.
 
 > [!WARNING]
 > Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_;

--- a/conf/test.config
+++ b/conf/test.config
@@ -31,3 +31,7 @@ params {
 
     cleanup                  = true //Otherwise tests dont run through properly.
 }
+
+// Include illumina config to run test without additional profiles
+
+includeConfig 'protocol_illumina.config'

--- a/conf/test_index.config
+++ b/conf/test_index.config
@@ -33,6 +33,3 @@ params {
     cleanup                  = true //Otherwise tests dont run through properly.
 }
 
-// Include illumina config to run test without additional profiles
-
-includeConfig 'protocol_illumina.config'

--- a/conf/test_index.config
+++ b/conf/test_index.config
@@ -33,3 +33,6 @@ params {
     cleanup                  = true //Otherwise tests dont run through properly.
 }
 
+// Include illumina config to run test without additional profiles
+
+includeConfig 'protocol_illumina.config'

--- a/conf/test_index.config
+++ b/conf/test_index.config
@@ -32,3 +32,7 @@ params {
 
     cleanup                  = true //Otherwise tests dont run through properly.
 }
+
+// Include illumina config to run test without additional profiles
+
+includeConfig 'protocol_illumina.config'

--- a/conf/test_no_genome.config
+++ b/conf/test_no_genome.config
@@ -28,3 +28,7 @@ params {
     skip_mirdeep     = true
 
 }
+
+// Include illumina config to run test without additional profiles
+
+includeConfig 'protocol_illumina.config'

--- a/conf/test_umi.config
+++ b/conf/test_umi.config
@@ -33,3 +33,7 @@ params {
     umitools_bc_pattern = '.+(?P<discard_1>AACTGTAGGCACCATCAAT){s<=2}(?P<umi_1>.{12})(?P<discard_2>.*)'
     save_umi_intermeds = true
 }
+
+// Include illumina config to run test without additional profiles
+
+includeConfig 'protocol_illumina.config'


### PR DESCRIPTION
The CI tests are currently executed with the profile configuration `-profile test,illumina,docker`, which differs from the typical `-profile test,docker` that most nf-core pipelines use. If the users run the pipeline with `-profile test,docker` it would lead to the protocol `custom` to be used, instead of `illumina`. This inconsistency could lead to confusion, as the standard user environment does not accurately reflect the same results as the CI test environment.

This PR addresses #371.
Closes #375 
It improves README documentation regarding how to use the protocol profiles.  
It includes the `illumina` protocol profiles directly in the test profiles so that users can run them out-of-the-box as they do with any other nf-core pipeline:

`nextflow run nf-core/smrnaseq -profile test,docker --outdir <results>`

<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
