### PR TITLE
 Fixing bugs for extracting Qiaseq UMI before trimming

### DIFF
--- a/workflows/smrnaseq.nf
+++ b/workflows/smrnaseq.nf
@@ -125,7 +125,7 @@ workflow NFCORE_SMRNASEQ {
     // This involves running on the sequencing adapter trimmed remnants of the entire reads
     // consisting of sequence + common sequence "miRNA adapter" + UMI
     // once collapsing happened, we will use umitools extract to get rid of the common miRNA sequence + the UMI to have only plain collapsed reads without any other clutter
-    if (params.with_umi) {
+    if (params.with_umi && params.skip_umi_extract_before_dedup) {
         ch_fastq = Channel.value('fastq')
         ch_input_for_collapse = ch_reads_for_mirna.map{ meta, reads -> [meta, reads, []]} //Needs to be done to add a []
         UMICOLLAPSE_FASTQ(ch_input_for_collapse, ch_fastq)
@@ -296,7 +296,7 @@ workflow NFCORE_SMRNASEQ {
         ch_multiqc_files = ch_multiqc_files.mix(FASTQ_FASTQC_UMITOOLS_FASTP.out.fastqc_raw_zip.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(FASTQ_FASTQC_UMITOOLS_FASTP.out.fastqc_trim_zip.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(FASTQ_FASTQC_UMITOOLS_FASTP.out.trim_json.collect{it[1]}.ifEmpty([]))
-        if(params.with_umi) {
+        if(params.with_umi && params.skip_umi_extract_before_dedup) {
             ch_multiqc_files = ch_multiqc_files.mix(UMICOLLAPSE_FASTQ.out.log.collect{it[1]}.ifEmpty([]))
         }
         ch_multiqc_files = ch_multiqc_files.mix(contamination_stats.collect().ifEmpty([]))


### PR DESCRIPTION
Detailed discussion can be seen here:
https://app.slack.com/client/TE6CZUZPH/activity

In short, the problem is:
When I run this command for Qiaseq protocol,
```
nextflow run nf-core/smrnaseq -profile docker,qiaseq -resume \
     --mirtrace_species "hsa" \
     --skip_mirdeep \
     --umitools_extract_method regex \
     --umitools_bc_pattern '.+(?P<discard_1>AACTGTAGGCACCATCAAT){s<=2}(?P<umi_1>.{12})(?P<discard_2>.*)' \
     --save_umi_intermeds \
     --with_umi
```
The adapter sequence (AACTGTAGGCACCATCAAT) is trimmed before UMITOOLS_EXTRACT, so that no UMI is identified and results in empty FASTQ for bowtie.

In order to solve this, we have to:

1. Activate `FASTQ_FASTQC_UMITOOLS_FASTP:UMITOOLS_EXTRACT` by `--skip_umi_extract_before_dedup false` (default is true).
2. Skip trimming by `--skip_fastp true` because `UMITOOLS_EXTRACT` trims the reads already.
3. Skip `NFCORE_SMRNASEQ:UMITOOLS_EXTRACT` when `FASTQ_FASTQC_UMITOOLS_FASTP:UMITOOLS_EXTRACT` is used.

When I use the command below, it works fine with **two-lines fixes** in this PR.
```
nextflow run /home/ckuo/github/smrnaseq -profile docker,qiaseq -resume \
     --input samplesheet_250213.csv \
     --outdir results_250213 \
     --mirtrace_species "hsa" \
     --skip_mirdeep \
     --skip_umi_extract_before_dedup false \
     --skip_fastp true \
     --umitools_extract_method regex \
     --umitools_bc_pattern '.+(?P<discard_1>AACTGTAGGCACCATCAAT){s<=2}(?P<umi_1>.{12})(?P<discard_2>.*)' \
     --save_umi_intermeds \
     --with_umi
```
