### PR TITLE
Feature bowtie align genome args

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -176,6 +176,11 @@ process {
         ]
     }
 
+    // Bowtie align arguments
+    withName: 'SMRNASEQ:GENOME_QUANT:BOWTIE_MAP_GENOME' {
+        ext.args = params.bowtie_align_args ? params.bowtie_align_args : ''
+    }
+
     withName: 'CLEAN_FASTA' {
         ext.args = "-c fastx '{gsub(/[^ATGCatgc]/, \"N\", \$seq); sub(/ .*/, \"\", \$name); print \">\"\$name\"\\n\"\$seq}'"
         ext.prefix = {"${meta.id}_clean.fa"}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,6 +53,7 @@ See examples in: [the test-datasets repository of nf-core](https://github.com/nf
 
 - `fasta`: the reference genome FASTA file
 - `bowtie_index`: points to the folder containing the `bowtie` indices for the genome reference specified by `fasta`.
+- `bowtie_align_args`: Optional flags to pass to Bowtie 1 for the genome mapping, e.g. `--bowtie_align_args '-v 1 --best'`. Only a subset of Bowtie 1 flags are allowed to keep compatibility with the pipeline. If invalid or disallowed values are included, the pipeline will exit with an error message.
 
 > [!NOTE]
 > if the FASTA file in `fasta` is not the same file used to generate the `bowtie` indices, then the pipeline will fail.

--- a/nextflow.config
+++ b/nextflow.config
@@ -72,6 +72,10 @@ params {
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes/'
     igenomes_ignore            = false
+
+    // Bowtie align options
+    bowtie_align_args          = ''
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -181,6 +181,14 @@
                     "fa_icon": "fas fa-book",
                     "help_text": "Point to the directory created by Bowtie 1 when indexing. Bowtie 1 indices consist of six files:\n\n```bash\ngenome.1.ebwt, genome.2.ebwt, genome.3.ebwt, genome.4.ebwt, genome.rev.1.ebwt, genome.rev.2.ebwt\n```\n"
                 },
+                "bowtie_align_args": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Additional arguments to pass to Bowtie alignment.",
+                    "help_text": "These flags are passed to Bowtie 1 for the genome mapping, e.g. `--bowtie_align_args '-v 1 --best'`. Use with caution as some flags may conflict with pipeline-managed options.",
+                    "fa_icon": "fas fa-terminal",
+                    "hidden": true
+                },
                 "save_reference": {
                     "type": "boolean",
                     "description": "Save generated reference genome files to results.",

--- a/subworkflows/local/utils_nfcore_smrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_smrnaseq_pipeline/main.nf
@@ -106,6 +106,11 @@ workflow PIPELINE_INITIALISATION {
     validateInputParameters()
 
     //
+    // Validate the bowtie align arguments provided through params.bowtie_align_args
+    //
+    validateBowtieGenomeArgs()
+
+    //
     // Create channel from input file provided through params.input
     //
 
@@ -248,6 +253,98 @@ def validateInputSamplesheet(input) {
     }
 
     return [ metas[0], fastqs ]
+}
+//
+// Validate the bowtie align arguments provided through params.bowtie_align_args
+//
+def validateBowtieGenomeArgs() {
+    if (!params.bowtie_align_args) return  // empty string is fine
+
+    // Allowlist: flag -> expected value type (null = flag only, 'int' = requires integer)
+    def ALLOWED_GENOME_ARGS = [
+    '-v'           : 'int_0_3',
+    '-n'           : 'int_0_3',
+    '--seedmms'    : 'int_0_3',
+    '-e'           : 'int',
+    '--maqerr'     : 'int',
+    '-l'           : 'int',
+    '--seedlen'    : 'int',
+    '-k'           : 'int',
+    '-m'           : 'int',
+    '--maxbts'     : 'int',
+    '--chunkmbs'   : 'int',
+    '--seed'       : 'int',
+    '--best'       : null,
+    '--strata'     : null,
+    '--nomaqround' : null,
+    '--norc'       : null,
+]
+
+    // Mutually exclusive pairs
+    def MUTEX_PAIRS = [
+        ['-v', '-n'],
+        ['-v', '--seedmms'],
+        ['--strata', '--best'],  // --strata requires --best, so flag if --strata without --best
+    ]
+
+    def tokens = params.bowtie_align_args.trim().split(/\s+/)
+    def i = 0
+    def seen = [] as Set
+
+    while (i < tokens.size()) {
+        def token = tokens[i]
+
+        // Handle --flag=value syntax by splitting on '='
+        def flag  = token
+        def value = null
+        if (token.contains('=')) {
+            def parts = token.split('=', 2)
+            flag  = parts[0]
+            value = parts[1]
+        }
+
+        if (!ALLOWED_GENOME_ARGS.containsKey(flag)) {
+            error "[bowtie_align_args] Argument '${flag}' is not allowed. " +
+                  "Only these flags are permitted: ${ALLOWED_GENOME_ARGS.keySet().sort().join(', ')}"
+        }
+
+        def expectedType = ALLOWED_GENOME_ARGS[flag]
+        seen << flag
+
+        if (expectedType != null) {
+            // Expect a value — either inline (--flag=val) or next token (--flag val)
+            if (value == null) {
+                i++
+                if (i >= tokens.size()) {
+                    error "[bowtie_align_args] Argument '${flag}' requires a value but none was provided."
+                }
+                value = tokens[i]
+            }
+
+            // Validate the value type
+            if (expectedType == 'int' || expectedType == 'int_0_3') {
+                if (!(value =~ /^\d+$/)) {
+                    error "[bowtie_align_args] Argument '${flag}' requires an integer value, got '${value}'."
+                }
+                if (expectedType == 'int_0_3' && !(value.toInteger() in 0..3)) {
+                    error "[bowtie_align_args] Argument '${flag}' must be between 0 and 3, got '${value}'."
+                }
+            }
+        } else if (value != null) {
+            // Flag-only arg was given a value via = syntax
+            error "[bowtie_align_args] Argument '${flag}' does not take a value, got '${value}'."
+        }
+
+        i++
+    }
+
+    // Mutual exclusivity checks
+    if (seen.contains('-v') && (seen.contains('-n') || seen.contains('--seedmms'))) {
+        error "[bowtie_align_args] '-v' and '-n'/'--seedmms' are mutually exclusive."
+    }
+    if (seen.contains('--strata') && !seen.contains('--best')) {
+        error "[bowtie_align_args] '--strata' requires '--best' to also be specified."
+    }
 }
 //
 // Get attribute from genome config file e.g. fasta


### PR DESCRIPTION
<!--
# nf-core/smrnaseq pull request

Many thanks for contributing to nf-core/smrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/smrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/smrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


Added the command line argument for custom Bowtie 1 genome mapping flags.
The user can pass the flags with the argument:
```
--bowtie_align_args "..."
```

A selected subset of flags is allowed to avoid interferences with the pipeline.