### PR TITLE
docs: clarify fastp behavior with UMI handling

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,9 @@ The pipeline handles UMIs with two tools. Umicollapse to deduplicate on entire r
 >
 > This warning is based on the execution order (`fastp` → `umicollapse` → `umi_tools extract`) and the resulting empty output when the adapter is trimmed before regex-based UMI extraction.
 >
-> In these cases where UMI trimming relies on the adapter sequence for the location of the UMIs, you can disable fastp trimming for the run (e.g. `--skip_fastp`).
+> In these cases where UMI trimming relies on the adapter sequence for the location of the UMIs, you can use
+> `--skip_fastp` to skip the initial adapter-trimming step. This does not disable `fastp` entirely: with `--with_umi`,
+> the pipeline still runs a separate `fastp` length-filtering step after `umi_tools extract`.
 
 ## Samplesheet input
 


### PR DESCRIPTION
## Summary

- clarify that `--skip_fastp` skips the initial adapter-trimming step
- document that UMI runs still use a separate `fastp` length filter after `umi_tools extract`

The current warning says that `--skip_fastp` disables fastp trimming for the run, but the workflow still invokes `FASTP_LENGTH_FILTER` after UMI extraction.

Closes #528.

## Validation

- checked the documented order against `workflows/smrnaseq.nf` and the `FASTQ_FASTQC_UMITOOLS_FASTP` subworkflow
- confirmed that the stale "disable fastp trimming for the run" wording is removed
- `git diff --check`

## PR checklist

- [x] This comment contains a description of changes and the reason
- [x] Usage documentation in `docs/usage.md` is updated
- [x] No pipeline code changed; runtime tests and changelog updates are not applicable

## Automation disclosure

This small documentation change was prepared and checked with OpenAI Codex automation. The wording was verified against the current workflow implementation; no human review is claimed.
